### PR TITLE
Tek830 a 28 improve logic motn

### DIFF
--- a/model/motn_scheduler.py
+++ b/model/motn_scheduler.py
@@ -1,0 +1,65 @@
+from model.scheduler import Scheduler
+from model.schedule import Schedule
+from model.events.lamp_event import LampEvent
+from model.events.lamp_action import LampAction
+from typing import List, Dict
+from matplotlib import pyplot as plt
+from datetime import datetime, time
+
+# This scheduler determines the state of a lamp at each minute by checking if, in the collected data, the lamp was on more often than off at this time of day.
+class MoreThanNotScheduler(Scheduler):
+    def __init__(self) -> None:
+        pass
+
+    def createSchedule(self, user_actions: List[LampEvent]) -> Schedule:
+        minutes = self.create_state_list(user_actions)
+
+        print(minutes)
+
+        events = self.create_event_list(minutes)
+        
+        return Schedule(events)
+
+    def create_state_list(self, user_actions):
+        minutes: List[Dict[str, int]] = [{} for _ in range(1440)]
+        active: List[str] = []
+        for i, minute in enumerate(minutes):
+            for action in user_actions:
+                if action.timestamp.hour * 60 + action.timestamp.minute == i:
+                    if action.action == LampAction.ON:
+                        active.append(action.lamp)
+                    else:
+                        active.remove(action.lamp)
+            for lamp in active:
+                minute[lamp] = minute.get(lamp, 0) + 1
+        return minutes
+
+    def create_event_list(self, minutes):
+        active = []
+        events: List[LampEvent] = []
+        for i, minute in enumerate(minutes):
+            for lamp, count in minute.items():
+                if count > 2 and lamp not in active:
+                    event = self.create_lamp_event(i, lamp, LampAction.ON)
+                    events.append(event)
+                    active.append(lamp)
+
+                elif (count <= 2 and lamp in active):
+                    event = self.create_lamp_event(i, lamp, LampAction.OFF)
+                    events.append(event)
+                    active.remove(lamp)
+            
+            for lamp in active:
+                if lamp not in minute.keys():
+                    event = self.create_lamp_event(i, lamp, LampAction.OFF)
+                    events.append(event)
+                    active.remove(lamp)
+        return events
+
+    def create_lamp_event(self, i, lamp, state):
+        return LampEvent(
+                        timestamp=datetime.combine(datetime.today(), time(i // 60, i % 60)),
+                        lamp=lamp,
+                        action=state
+                    )
+                    

--- a/model/motn_scheduler.py
+++ b/model/motn_scheduler.py
@@ -12,15 +12,12 @@ class MoreThanNotScheduler(Scheduler):
         pass
 
     def createSchedule(self, user_actions: List[LampEvent]) -> Schedule:
-        minutes = self.create_minute_list(user_actions)
-
-        print(minutes)
-
-        events = self.create_event_list(minutes)
+        minutes: List[Dict[str, int]] = self.create_minute_list(user_actions)
+        events: List[LampEvent] = self.create_event_list(minutes)
         
         return Schedule(events)
 
-    def create_minute_list(self, user_actions):
+    def create_minute_list(self, user_actions) -> List[Dict[str, int]]:
         """Creates a list of dictionaries, each representing a minute of the day, with the number of times each lamp was on during that minute in each day."""
         minutes: List[Dict[str, int]] = [{} for _ in range(1440)]
         active: List[str] = []
@@ -37,10 +34,10 @@ class MoreThanNotScheduler(Scheduler):
                 minute[lamp] = minute.get(lamp, 0) + 1
         return minutes
 
-    def create_event_list(self, minutes):
+    def create_event_list(self, minutes) -> List[LampEvent]:
         """Creates a list of events based on if a lamp was on more often than off at a given minute."""
-        count_threshold = self.calculate_count_threshold(minutes)
-        active = []
+        count_threshold: int = self.calculate_count_threshold(minutes)
+        active: List[str] = []
         events: List[LampEvent] = []
         for i, minute in enumerate(minutes):
             for lamp, count in minute.items():
@@ -61,16 +58,16 @@ class MoreThanNotScheduler(Scheduler):
                     active.remove(lamp)
         return events
 
-    def calculate_count_threshold(self, minutes):
+    def calculate_count_threshold(self, minutes) -> int:
         """Calculates the threshold for the number of times a lamp must be on in a minute for it to be scheduled to be on. The threshold is half the maximum number of times a lamp was on in a minute."""
-        counts = []
+        counts: List[int] = []
         for minute in minutes:
             for lamp, count in minute.items():
                 counts.append(count)
         count_threshold = max(counts) // 2
         return count_threshold
 
-    def create_lamp_event(self, i, lamp, state):
+    def create_lamp_event(self, i, lamp, state) -> LampEvent:
         return LampEvent(
                         timestamp=datetime.combine(datetime.today(), time(i // 60, i % 60)),
                         lamp=lamp,

--- a/model/motn_scheduler.py
+++ b/model/motn_scheduler.py
@@ -35,16 +35,17 @@ class MoreThanNotScheduler(Scheduler):
         return minutes
 
     def create_event_list(self, minutes):
+        count_threshold = self.calculate_count_threshold(minutes)
         active = []
         events: List[LampEvent] = []
         for i, minute in enumerate(minutes):
             for lamp, count in minute.items():
-                if count > 2 and lamp not in active:
+                if count > count_threshold and lamp not in active:
                     event = self.create_lamp_event(i, lamp, LampAction.ON)
                     events.append(event)
                     active.append(lamp)
 
-                elif (count <= 2 and lamp in active):
+                elif (count <= count_threshold and lamp in active):
                     event = self.create_lamp_event(i, lamp, LampAction.OFF)
                     events.append(event)
                     active.remove(lamp)
@@ -55,6 +56,14 @@ class MoreThanNotScheduler(Scheduler):
                     events.append(event)
                     active.remove(lamp)
         return events
+
+    def calculate_count_threshold(self, minutes):
+        counts = []
+        for minute in minutes:
+            for lamp, count in minute.items():
+                counts.append(count)
+        count_threshold = max(counts) // 2
+        return count_threshold
 
     def create_lamp_event(self, i, lamp, state):
         return LampEvent(


### PR DESCRIPTION
Adds a scheduler that for each of the 1440 minutes in a day counts the number of days that the lamp was turned on during this minute. It then schedules the lamp to be on during this minute if it was on more days than it was off.

If you always have the living room lamp on 18-23, it will be added to the schedule.
If you have the kitchen lamp on 19-21 more often than not (maybe because you don't always cook), then it will be added to the schedule anyways. 
Random, unpredictable actions like going to the bathroom will be filtered out since the bathroom lamp will be turned off more often than on at these minutes of the day.